### PR TITLE
Add polygon render mode for unstructured mesh visualization

### DIFF
--- a/src/interface/x_interface.c
+++ b/src/interface/x_interface.c
@@ -128,6 +128,12 @@ static SaveCallback save_cb = NULL;
 typedef void (*DimNavCallback)(int dim_index, int direction);
 static DimNavCallback dim_nav_cb = NULL;
 
+typedef void (*RenderModeCallback)(void);
+static RenderModeCallback render_mode_cb = NULL;
+
+/* Render mode button */
+static Widget render_mode_button = NULL;
+
 /* State */
 static size_t current_n_times = 1;
 static size_t current_n_depths = 1;
@@ -213,6 +219,11 @@ static void zoom_out_callback(Widget w, XtPointer client_data, XtPointer call_da
 static void save_callback_fn(Widget w, XtPointer client_data, XtPointer call_data) {
     (void)w; (void)client_data; (void)call_data;
     if (save_cb) save_cb();
+}
+
+static void render_mode_callback_fn(Widget w, XtPointer client_data, XtPointer call_data) {
+    (void)w; (void)client_data; (void)call_data;
+    if (render_mode_cb) render_mode_cb();
 }
 
 /* Dimension current button click - advance forward */
@@ -417,6 +428,7 @@ int x_init(int *argc, char **argv, const char **var_names, int n_vars,
         "buttonbox", boxWidgetClass, main_form,
         XtNorientation, XtorientHorizontal,
         XtNfromVert, label_value,
+        XtNwidth, 580,
         NULL
     );
 
@@ -477,6 +489,7 @@ int x_init(int *argc, char **argv, const char **var_names, int n_vars,
         "optionbox", boxWidgetClass, main_form,
         XtNorientation, XtorientHorizontal,
         XtNfromVert, buttonbox,
+        XtNwidth, 580,
         NULL
     );
 
@@ -516,6 +529,12 @@ int x_init(int *argc, char **argv, const char **var_names, int n_vars,
     btn = XtVaCreateManagedWidget("Save", commandWidgetClass, optionbox,
         XtNwidth, BUTTON_WIDTH, NULL);
     XtAddCallback(btn, XtNcallback, save_callback_fn, NULL);
+
+    render_mode_button = XtVaCreateManagedWidget("Interp", commandWidgetClass, optionbox,
+        XtNwidth, BUTTON_WIDTH + 10,
+        XtNresize, False,
+        NULL);
+    XtAddCallback(render_mode_button, XtNcallback, render_mode_callback_fn, NULL);
 
     /* ===== Colorbar ===== */
     colorbar_form = XtVaCreateManagedWidget(
@@ -675,6 +694,13 @@ void x_set_range_callback(void (*cb)(int)) { range_adjust_cb = cb; }
 void x_set_zoom_callback(void (*cb)(int)) { zoom_cb = cb; }
 void x_set_save_callback(void (*cb)(void)) { save_cb = cb; }
 void x_set_dim_nav_callback(DimNavCallback cb) { dim_nav_cb = cb; }
+void x_set_render_mode_callback(void (*cb)(void)) { render_mode_cb = cb; }
+
+void x_update_render_mode_label(const char *mode_name) {
+    if (render_mode_button && mode_name) {
+        XtVaSetValues(render_mode_button, XtNlabel, mode_name, NULL);
+    }
+}
 
 /* ========== Variable Selector ========== */
 

--- a/src/interface/x_interface.h
+++ b/src/interface/x_interface.h
@@ -33,6 +33,12 @@ void x_set_mouse_callback(void (*cb)(int x, int y));
 void x_set_range_callback(void (*cb)(int action));  /* 0=min-, 1=min+, 2=max-, 3=max+ */
 void x_set_zoom_callback(void (*cb)(int delta));    /* +1=zoom in, -1=zoom out */
 void x_set_save_callback(void (*cb)(void));         /* save button pressed */
+void x_set_render_mode_callback(void (*cb)(void));  /* toggle render mode */
+
+/*
+ * Update render mode label.
+ */
+void x_update_render_mode_label(const char *mode_name);
 
 /*
  * Set up variable selector buttons.

--- a/src/mesh.h
+++ b/src/mesh.h
@@ -47,6 +47,13 @@ USMesh *mesh_create_from_zarr(USFile *file);
 #endif
 
 /*
+ * Load element connectivity from an external NetCDF mesh file.
+ * This enables polygon rendering mode.
+ * Returns 0 on success, -1 on failure.
+ */
+int mesh_load_connectivity(USMesh *mesh, const char *mesh_filename);
+
+/*
  * Free mesh and all associated memory.
  */
 void mesh_free(USMesh *mesh);

--- a/src/ushow.defines.h
+++ b/src/ushow.defines.h
@@ -73,6 +73,11 @@ struct USMesh {
     CoordType   coord_type;
     size_t      orig_nx, orig_ny;   /* Original grid dimensions if structured */
 
+    /* Element connectivity for polygon rendering (triangular elements) */
+    size_t      n_elements;         /* Number of triangular elements */
+    int         n_vertices;         /* Vertices per element (3 for triangles) */
+    int        *elem_nodes;         /* Node indices [n_elements * n_vertices] */
+
     /* Mesh file info (for unstructured data with separate mesh) */
     char       *mesh_filename;
     int         mesh_loaded;
@@ -172,12 +177,21 @@ struct USFileSet {
     char       *base_filename;      /* First filename (for display) */
 };
 
+/* Render mode */
+typedef enum {
+    RENDER_MODE_INTERPOLATE = 0,    /* Default: regrid to regular grid */
+    RENDER_MODE_POLYGON             /* Render actual mesh polygons */
+} RenderMode;
+
 /* Current view state */
 struct USView {
     USVar      *variable;           /* Current variable being displayed */
     USMesh     *mesh;               /* Current mesh/coordinates */
     USRegrid   *regrid;             /* Current regridding setup */
     USFileSet  *fileset;            /* Multi-file set (NULL for single file) */
+
+    /* Render mode */
+    RenderMode  render_mode;        /* Interpolate or polygon rendering */
 
     /* Current position in data space */
     size_t      time_index;         /* Current time step (virtual if fileset) */
@@ -215,6 +229,7 @@ typedef struct {
     double      target_resolution;  /* Target grid resolution in degrees */
     char        mesh_file[MAX_NAME_LEN];  /* Separate mesh file path */
     int         frame_delay_ms;     /* Animation speed */
+    int         polygon_only;       /* Skip regridding, polygon mode only */
 } USOptions;
 
 /* Dimension info for display */

--- a/src/view.h
+++ b/src/view.h
@@ -46,6 +46,23 @@ int view_step_time(USView *view, int delta);
 int view_set_scale(USView *view, int scale);
 
 /*
+ * Set render mode (interpolate or polygon).
+ * Returns 0 on success, -1 if polygon mode unavailable.
+ */
+int view_set_render_mode(USView *view, RenderMode mode);
+
+/*
+ * Toggle render mode between interpolate and polygon.
+ * Returns new mode, or -1 if polygon mode unavailable.
+ */
+int view_toggle_render_mode(USView *view);
+
+/*
+ * Check if polygon rendering is available for current mesh.
+ */
+int view_polygon_available(USView *view);
+
+/*
  * Update display: read data, regrid, and convert to pixels.
  */
 int view_update(USView *view);


### PR DESCRIPTION
Features:
- New render mode that displays actual mesh triangles without interpolation
- Load element connectivity (face_nodes) from mesh files
- Toggle button in UI to switch between Interpolate and Polygon modes
- New --polygon-only (-p) flag to skip slow regridding step

Usage:
  ushow -m mesh.nc data.nc          # Toggle with button
  ushow -p -m mesh.nc data.nc       # Polygon-only (faster startup)