### PR TITLE
Add Range capability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,9 @@ COMMON_SRCS = $(SRCDIR)/kdtree.c \
 USHOW_SRCS = $(SRCDIR)/ushow.c \
              $(COMMON_SRCS) \
              $(SRCDIR)/interface/x_interface.c \
-             $(SRCDIR)/interface/colorbar.c
+             $(SRCDIR)/interface/colorbar.c \
+             $(SRCDIR)/interface/range_popup.c \
+             $(SRCDIR)/interface/range_utils.c
 
 UTERM_SRCS = $(SRCDIR)/uterm.c \
              $(SRCDIR)/term_render_mode.c \
@@ -210,6 +212,11 @@ $(OBJDIR)/interface/x_interface.o: $(SRCDIR)/interface/x_interface.c \
                                     $(SRCDIR)/interface/colorbar.h $(SRCDIR)/ushow.defines.h
 $(OBJDIR)/interface/colorbar.o: $(SRCDIR)/interface/colorbar.c \
                                  $(SRCDIR)/interface/colorbar.h $(SRCDIR)/colormaps.h
+$(OBJDIR)/interface/range_popup.o: $(SRCDIR)/interface/range_popup.c \
+                                    $(SRCDIR)/interface/range_popup.h \
+                                    $(SRCDIR)/interface/range_utils.h
+$(OBJDIR)/interface/range_utils.o: $(SRCDIR)/interface/range_utils.c \
+                                    $(SRCDIR)/interface/range_utils.h
 
 # Zarr dependencies (when WITH_ZARR is set)
 ifdef WITH_ZARR

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The test suite includes:
 - **test_regrid**: Interpolation to regular grids
 - **test_colormaps**: Color mapping functions
 - **test_term_render_mode**: Terminal render mode parsing/cycling helpers
+- **test_range_popup**: Range popup logic (symmetric computation, value parsing)
 - **test_file_netcdf**: NetCDF file I/O
 - **test_file_zarr**: Zarr file I/O (when built with `WITH_ZARR=1`)
 - **test_integration**: End-to-end workflow tests
@@ -205,6 +206,11 @@ The test suite includes:
   - `Fwd >`: Start forward animation
 - **Time/Depth sliders**: Navigate through dimensions
 - **Colormap button**: Click to cycle through colormaps
+- **Min-/Min+/Max-/Max+**: Adjust display range in 10% steps
+- **Range button**: Opens a popup dialog to set the display range explicitly:
+  - **Minimum/Maximum**: Editable text fields for exact values
+  - **Symmetric about Zero**: Sets range to [-max(|min|,|max|), max(|min|,|max|)]
+  - **Reset to Global Values**: Restores the variable's full data range
 - **Dimension panel**: Shows dimension names, ranges, current values
 - **Colorbar**: Min/max and intermediate labels update as you adjust range
 

--- a/src/interface/range_popup.c
+++ b/src/interface/range_popup.c
@@ -1,0 +1,237 @@
+/*
+ * range_popup.c - Range popup dialog for setting min/max values
+ *
+ * Inspired by ncview's range.c popup dialog.
+ * Modal popup with editable min/max text fields,
+ * "Symmetric about Zero" and "Reset to Global Values" buttons.
+ */
+
+#include "range_popup.h"
+#include "range_utils.h"
+#include <X11/Xlib.h>
+#include <X11/StringDefs.h>
+#include <X11/Shell.h>
+#include <X11/Xaw/Form.h>
+#include <X11/Xaw/Label.h>
+#include <X11/Xaw/Command.h>
+#include <X11/Xaw/AsciiText.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#define MINMAX_TEXT_WIDTH 120
+
+/* X11 handles (passed during init) */
+static Display *popup_display = NULL;
+static XtAppContext popup_app_context;
+
+/* Popup widgets */
+static Widget range_popup_shell = NULL;
+static Widget range_form = NULL;
+static Widget range_min_label = NULL;
+static Widget range_min_text = NULL;
+static Widget range_max_label = NULL;
+static Widget range_max_text = NULL;
+static Widget range_symmetric_btn = NULL;
+static Widget range_reset_btn = NULL;
+static Widget range_global_label = NULL;
+static Widget range_ok_btn = NULL;
+static Widget range_cancel_btn = NULL;
+
+/* Modal loop state */
+static int popup_done = 0;
+static int popup_result = RANGE_POPUP_CANCEL;
+
+/* Global range for "Reset to Global Values" */
+static float stored_global_min = 0.0f;
+static float stored_global_max = 1.0f;
+
+/* ========== Callbacks ========== */
+
+static void ok_callback(Widget w, XtPointer client_data, XtPointer call_data) {
+    (void)w; (void)client_data; (void)call_data;
+    popup_result = RANGE_POPUP_OK;
+    popup_done = 1;
+}
+
+static void cancel_callback(Widget w, XtPointer client_data, XtPointer call_data) {
+    (void)w; (void)client_data; (void)call_data;
+    popup_result = RANGE_POPUP_CANCEL;
+    popup_done = 1;
+}
+
+static void symmetric_callback(Widget w, XtPointer client_data, XtPointer call_data) {
+    (void)w; (void)client_data; (void)call_data;
+    char *sptr;
+    float cur_min, cur_max, new_min, new_max;
+    char tstr[128];
+
+    XtVaGetValues(range_min_text, XtNstring, &sptr, NULL);
+    if (sscanf(sptr, "%g", &cur_min) != 1) return;
+    XtVaGetValues(range_max_text, XtNstring, &sptr, NULL);
+    if (sscanf(sptr, "%g", &cur_max) != 1) return;
+
+    range_compute_symmetric(cur_min, cur_max, &new_min, &new_max);
+
+    snprintf(tstr, sizeof(tstr), "%g", new_min);
+    XtVaSetValues(range_min_text, XtNstring, tstr, NULL);
+
+    snprintf(tstr, sizeof(tstr), "%g", new_max);
+    XtVaSetValues(range_max_text, XtNstring, tstr, NULL);
+}
+
+static void reset_global_callback(Widget w, XtPointer client_data, XtPointer call_data) {
+    (void)w; (void)client_data; (void)call_data;
+    char tstr[128];
+
+    snprintf(tstr, sizeof(tstr), "%g", stored_global_min);
+    XtVaSetValues(range_min_text, XtNstring, tstr, NULL);
+
+    snprintf(tstr, sizeof(tstr), "%g", stored_global_max);
+    XtVaSetValues(range_max_text, XtNstring, tstr, NULL);
+}
+
+/* ========== Public API ========== */
+
+void range_popup_init(Widget parent, Display *dpy, XtAppContext app_ctx) {
+    popup_display = dpy;
+    popup_app_context = app_ctx;
+
+    /* Popup shell */
+    range_popup_shell = XtVaCreatePopupShell(
+        "Set Range",
+        transientShellWidgetClass,
+        parent,
+        NULL);
+
+    /* Form container */
+    range_form = XtVaCreateManagedWidget(
+        "rangeForm", formWidgetClass, range_popup_shell,
+        XtNborderWidth, 0,
+        NULL);
+
+    /* Row 1: Minimum label + text */
+    range_min_label = XtVaCreateManagedWidget(
+        "range_min_label", labelWidgetClass, range_form,
+        XtNlabel, "Minimum:",
+        XtNwidth, 80,
+        XtNborderWidth, 0,
+        NULL);
+
+    range_min_text = XtVaCreateManagedWidget(
+        "range_min_text", asciiTextWidgetClass, range_form,
+        XtNeditType, XawtextEdit,
+        XtNfromHoriz, range_min_label,
+        XtNwidth, MINMAX_TEXT_WIDTH,
+        NULL);
+
+    /* Row 2: Maximum label + text */
+    range_max_label = XtVaCreateManagedWidget(
+        "range_max_label", labelWidgetClass, range_form,
+        XtNlabel, "Maximum:",
+        XtNwidth, 80,
+        XtNborderWidth, 0,
+        XtNfromVert, range_min_label,
+        NULL);
+
+    range_max_text = XtVaCreateManagedWidget(
+        "range_max_text", asciiTextWidgetClass, range_form,
+        XtNeditType, XawtextEdit,
+        XtNfromHoriz, range_max_label,
+        XtNfromVert, range_min_text,
+        XtNwidth, MINMAX_TEXT_WIDTH,
+        NULL);
+
+    /* Row 3: Symmetric about Zero */
+    range_symmetric_btn = XtVaCreateManagedWidget(
+        "Symmetric about Zero", commandWidgetClass, range_form,
+        XtNfromVert, range_max_label,
+        NULL);
+    XtAddCallback(range_symmetric_btn, XtNcallback, symmetric_callback, NULL);
+
+    /* Row 4: Reset to Global Values + label showing values */
+    range_reset_btn = XtVaCreateManagedWidget(
+        "Reset to Global Values", commandWidgetClass, range_form,
+        XtNfromVert, range_symmetric_btn,
+        NULL);
+    XtAddCallback(range_reset_btn, XtNcallback, reset_global_callback, NULL);
+
+    range_global_label = XtVaCreateManagedWidget(
+        "range_global_label", labelWidgetClass, range_form,
+        XtNborderWidth, 0,
+        XtNfromVert, range_symmetric_btn,
+        XtNfromHoriz, range_reset_btn,
+        XtNwidth, 180,
+        XtNlabel, "",
+        NULL);
+
+    /* Row 5: OK / Cancel */
+    range_ok_btn = XtVaCreateManagedWidget(
+        "OK", commandWidgetClass, range_form,
+        XtNfromVert, range_reset_btn,
+        NULL);
+    XtAddCallback(range_ok_btn, XtNcallback, ok_callback, NULL);
+
+    range_cancel_btn = XtVaCreateManagedWidget(
+        "Cancel", commandWidgetClass, range_form,
+        XtNfromHoriz, range_ok_btn,
+        XtNfromVert, range_reset_btn,
+        NULL);
+    XtAddCallback(range_cancel_btn, XtNcallback, cancel_callback, NULL);
+}
+
+int range_popup_show(float old_min, float old_max,
+                     float global_min, float global_max,
+                     float *new_min, float *new_max) {
+    if (!range_popup_shell) return RANGE_POPUP_CANCEL;
+
+    char min_str[128], max_str[128], global_str[128];
+    XEvent event;
+
+    /* Store global range for reset button */
+    stored_global_min = global_min;
+    stored_global_max = global_max;
+
+    /* Set current values in text fields */
+    snprintf(min_str, sizeof(min_str), "%g", old_min);
+    snprintf(max_str, sizeof(max_str), "%g", old_max);
+    XtVaSetValues(range_min_text, XtNstring, min_str, NULL);
+    XtVaSetValues(range_max_text, XtNstring, max_str, NULL);
+
+    /* Update global values label */
+    snprintf(global_str, sizeof(global_str), "%g to %g", global_min, global_max);
+    XtVaSetValues(range_global_label, XtNlabel, global_str, NULL);
+
+    /* Initialize output values */
+    *new_min = old_min;
+    *new_max = old_max;
+
+    /* Show popup (modal) */
+    XtPopup(range_popup_shell, XtGrabExclusive);
+
+    /* Modal event loop */
+    popup_done = 0;
+    while (!popup_done) {
+        XtAppNextEvent(popup_app_context, &event);
+        XtDispatchEvent(&event);
+    }
+
+    /* Read values if OK was pressed */
+    if (popup_result == RANGE_POPUP_OK) {
+        char *sptr;
+        XtVaGetValues(range_min_text, XtNstring, &sptr, NULL);
+        sscanf(sptr, "%g", new_min);
+        XtVaGetValues(range_max_text, XtNstring, &sptr, NULL);
+        sscanf(sptr, "%g", new_max);
+    }
+
+    XtPopdown(range_popup_shell);
+
+    return popup_result;
+}
+
+void range_popup_cleanup(void) {
+    /* Widgets are destroyed as children of top_level */
+    range_popup_shell = NULL;
+}

--- a/src/interface/range_popup.h
+++ b/src/interface/range_popup.h
@@ -1,0 +1,38 @@
+/*
+ * range_popup.h - Range popup dialog for setting min/max values
+ *
+ * Modal popup with editable min/max text fields,
+ * "Symmetric about Zero" and "Reset to Global Values" buttons.
+ */
+
+#ifndef RANGE_POPUP_H
+#define RANGE_POPUP_H
+
+#include <X11/Intrinsic.h>
+#include "range_utils.h"
+
+/*
+ * Initialize the range popup widgets.
+ * Must be called after XtRealizeWidget(top_level).
+ */
+void range_popup_init(Widget parent, Display *dpy, XtAppContext app_ctx);
+
+/*
+ * Show the range popup dialog (modal).
+ *
+ * old_min/old_max: current display range
+ * global_min/global_max: full data range for "Reset to Global Values"
+ * new_min/new_max: output values set by user
+ *
+ * Returns RANGE_POPUP_OK or RANGE_POPUP_CANCEL.
+ */
+int range_popup_show(float old_min, float old_max,
+                     float global_min, float global_max,
+                     float *new_min, float *new_max);
+
+/*
+ * Cleanup range popup resources.
+ */
+void range_popup_cleanup(void);
+
+#endif /* RANGE_POPUP_H */

--- a/src/interface/range_utils.c
+++ b/src/interface/range_utils.c
@@ -1,0 +1,24 @@
+/*
+ * range_utils.c - Pure logic utilities for range manipulation
+ *
+ * No X11 dependency - can be used in tests and non-GUI code.
+ */
+
+#include "range_utils.h"
+#include <math.h>
+#include <stdio.h>
+
+void range_compute_symmetric(float cur_min, float cur_max,
+                             float *new_min, float *new_max) {
+    float biggest = fabsf(cur_min) > fabsf(cur_max) ? fabsf(cur_min) : fabsf(cur_max);
+    *new_min = -biggest;
+    *new_max = biggest;
+}
+
+int range_parse_value(const char *str, float *value) {
+    if (!str || !value) return 0;
+    float v;
+    if (sscanf(str, "%g", &v) != 1) return 0;
+    *value = v;
+    return 1;
+}

--- a/src/interface/range_utils.h
+++ b/src/interface/range_utils.h
@@ -1,0 +1,26 @@
+/*
+ * range_utils.h - Pure logic utilities for range manipulation
+ *
+ * No X11 dependency - can be used in tests and non-GUI code.
+ */
+
+#ifndef RANGE_UTILS_H
+#define RANGE_UTILS_H
+
+#define RANGE_POPUP_OK     1
+#define RANGE_POPUP_CANCEL 0
+
+/*
+ * Compute symmetric range about zero.
+ * Sets new_min = -max(|cur_min|, |cur_max|), new_max = max(|cur_min|, |cur_max|).
+ */
+void range_compute_symmetric(float cur_min, float cur_max,
+                             float *new_min, float *new_max);
+
+/*
+ * Parse a range value from a string.
+ * Returns 1 on success, 0 on failure. On failure, *value is unchanged.
+ */
+int range_parse_value(const char *str, float *value);
+
+#endif /* RANGE_UTILS_H */

--- a/src/interface/x_interface.h
+++ b/src/interface/x_interface.h
@@ -34,6 +34,7 @@ void x_set_range_callback(void (*cb)(int action));  /* 0=min-, 1=min+, 2=max-, 3
 void x_set_zoom_callback(void (*cb)(int delta));    /* +1=zoom in, -1=zoom out */
 void x_set_save_callback(void (*cb)(void));         /* save button pressed */
 void x_set_render_mode_callback(void (*cb)(void));  /* toggle render mode */
+void x_set_range_button_callback(void (*cb)(void)); /* Range button pressed */
 
 /*
  * Update render mode label.
@@ -101,6 +102,14 @@ void x_update_value_label(double lon, double lat, float value);
  * height: colorbar height in pixels (should match image height)
  */
 void x_update_colorbar(float min_val, float max_val, size_t height);
+
+/*
+ * Show range popup dialog (modal).
+ * Returns RANGE_POPUP_OK (1) or RANGE_POPUP_CANCEL (0).
+ */
+int x_range_popup_show(float old_min, float old_max,
+                       float global_min, float global_max,
+                       float *new_min, float *new_max);
 
 /*
  * Set animation timer.

--- a/src/ushow.c
+++ b/src/ushow.c
@@ -289,6 +289,23 @@ static void on_save(void) {
     }
 }
 
+static void on_range_button(void) {
+    if (!current_var) return;
+
+    float new_min, new_max;
+    int result = x_range_popup_show(
+        current_var->user_min, current_var->user_max,
+        current_var->global_min, current_var->global_max,
+        &new_min, &new_max);
+
+    if (result == 1) {  /* RANGE_POPUP_OK */
+        current_var->user_min = new_min;
+        current_var->user_max = new_max;
+        x_update_range_label(current_var->user_min, current_var->user_max);
+        update_display();
+    }
+}
+
 static void on_render_mode_toggle(void) {
     if (!view) return;
     
@@ -932,6 +949,7 @@ int main(int argc, char *argv[]) {
     x_set_save_callback(on_save);
     x_set_dim_nav_callback(on_dim_nav);
     x_set_render_mode_callback(on_render_mode_toggle);
+    x_set_range_button_callback(on_range_button);
 
     /* Create view */
     view = view_create();

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -47,7 +47,7 @@ endif
 SRCDIR = ../src
 
 # Test executables
-TEST_TARGETS = test_kdtree test_mesh test_regrid test_colormaps test_file_netcdf test_integration test_term_render_mode
+TEST_TARGETS = test_kdtree test_mesh test_regrid test_colormaps test_file_netcdf test_integration test_term_render_mode test_range_popup
 
 # Add zarr test if enabled
 ifdef WITH_ZARR
@@ -96,6 +96,11 @@ test_integration: test_integration.c $(FILE_NETCDF_OBJ) $(MESH_DEPS) $(KDTREE_OB
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 test_term_render_mode: test_term_render_mode.c $(SRCDIR)/term_render_mode.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+
+RANGE_UTILS_OBJ = $(SRCDIR)/interface/range_utils.c
+
+test_range_popup: test_range_popup.c $(RANGE_UTILS_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 # Zarr test (only built with WITH_ZARR=1)
@@ -149,6 +154,9 @@ test-integration: test_integration
 test-term-render-mode: test_term_render_mode
 	./test_term_render_mode
 
+test-range-popup: test_range_popup
+	./test_range_popup
+
 test-zarr: test_file_zarr
 	./test_file_zarr
 
@@ -185,6 +193,7 @@ help:
 	@echo "  test-zarr    - Run Zarr tests only (requires WITH_ZARR=1)"
 	@echo "  test-integration - Run Integration tests only"
 	@echo "  test-term-render-mode - Run terminal render mode tests only"
+	@echo "  test-range-popup - Run range popup logic tests only"
 	@echo "  memcheck     - Run valgrind memory check on all tests"
 	@echo "  clean        - Remove test executables and temp files"
 	@echo "  help         - Show this help message"

--- a/tests/test_range_popup.c
+++ b/tests/test_range_popup.c
@@ -1,0 +1,235 @@
+/*
+ * test_range_popup.c - Unit tests for range popup logic
+ *
+ * Tests the pure logic functions (symmetric computation, value parsing)
+ * that don't require an X11 display.
+ */
+
+#include "test_framework.h"
+#include "../src/interface/range_utils.h"
+#include <float.h>
+
+#define EPSILON 1e-6f
+
+/* ========== range_compute_symmetric tests ========== */
+
+/* Basic symmetric: positive range [2, 10] -> [-10, 10] */
+TEST(symmetric_positive_range) {
+    float new_min, new_max;
+    range_compute_symmetric(2.0f, 10.0f, &new_min, &new_max);
+    ASSERT_NEAR(new_min, -10.0f, EPSILON);
+    ASSERT_NEAR(new_max, 10.0f, EPSILON);
+    return 1;
+}
+
+/* Symmetric: negative range [-10, -2] -> [-10, 10] */
+TEST(symmetric_negative_range) {
+    float new_min, new_max;
+    range_compute_symmetric(-10.0f, -2.0f, &new_min, &new_max);
+    ASSERT_NEAR(new_min, -10.0f, EPSILON);
+    ASSERT_NEAR(new_max, 10.0f, EPSILON);
+    return 1;
+}
+
+/* Symmetric: range spanning zero [-3, 5] -> [-5, 5] */
+TEST(symmetric_spanning_zero) {
+    float new_min, new_max;
+    range_compute_symmetric(-3.0f, 5.0f, &new_min, &new_max);
+    ASSERT_NEAR(new_min, -5.0f, EPSILON);
+    ASSERT_NEAR(new_max, 5.0f, EPSILON);
+    return 1;
+}
+
+/* Symmetric: min has larger abs [-8, 5] -> [-8, 8] */
+TEST(symmetric_min_larger_abs) {
+    float new_min, new_max;
+    range_compute_symmetric(-8.0f, 5.0f, &new_min, &new_max);
+    ASSERT_NEAR(new_min, -8.0f, EPSILON);
+    ASSERT_NEAR(new_max, 8.0f, EPSILON);
+    return 1;
+}
+
+/* Symmetric: already symmetric [-5, 5] -> [-5, 5] */
+TEST(symmetric_already_symmetric) {
+    float new_min, new_max;
+    range_compute_symmetric(-5.0f, 5.0f, &new_min, &new_max);
+    ASSERT_NEAR(new_min, -5.0f, EPSILON);
+    ASSERT_NEAR(new_max, 5.0f, EPSILON);
+    return 1;
+}
+
+/* Symmetric: both zero [0, 0] -> [0, 0] */
+TEST(symmetric_both_zero) {
+    float new_min, new_max;
+    range_compute_symmetric(0.0f, 0.0f, &new_min, &new_max);
+    ASSERT_NEAR(new_min, 0.0f, EPSILON);
+    ASSERT_NEAR(new_max, 0.0f, EPSILON);
+    return 1;
+}
+
+/* Symmetric: one is zero [0, 7] -> [-7, 7] */
+TEST(symmetric_min_zero) {
+    float new_min, new_max;
+    range_compute_symmetric(0.0f, 7.0f, &new_min, &new_max);
+    ASSERT_NEAR(new_min, -7.0f, EPSILON);
+    ASSERT_NEAR(new_max, 7.0f, EPSILON);
+    return 1;
+}
+
+/* Symmetric: equal magnitude [-5, 5] stays same */
+TEST(symmetric_equal_magnitude) {
+    float new_min, new_max;
+    range_compute_symmetric(-5.0f, 5.0f, &new_min, &new_max);
+    ASSERT_NEAR(new_min, -5.0f, EPSILON);
+    ASSERT_NEAR(new_max, 5.0f, EPSILON);
+    return 1;
+}
+
+/* Symmetric: very small values */
+TEST(symmetric_small_values) {
+    float new_min, new_max;
+    range_compute_symmetric(-1e-10f, 2e-10f, &new_min, &new_max);
+    ASSERT_NEAR(new_min, -2e-10f, 1e-16f);
+    ASSERT_NEAR(new_max, 2e-10f, 1e-16f);
+    return 1;
+}
+
+/* Symmetric: very large values */
+TEST(symmetric_large_values) {
+    float new_min, new_max;
+    range_compute_symmetric(-1e20f, 5e19f, &new_min, &new_max);
+    ASSERT_NEAR(new_min, -1e20f, 1e14f);
+    ASSERT_NEAR(new_max, 1e20f, 1e14f);
+    return 1;
+}
+
+/* Symmetric: result is always symmetric about zero */
+TEST(symmetric_result_always_symmetric) {
+    float new_min, new_max;
+
+    /* Test multiple cases */
+    float test_mins[] = {-3.0f, 0.0f, 1.0f, -100.0f, -0.5f};
+    float test_maxs[] = {7.0f, 4.0f, 9.0f, 50.0f, 0.1f};
+
+    for (int i = 0; i < 5; i++) {
+        range_compute_symmetric(test_mins[i], test_maxs[i], &new_min, &new_max);
+        ASSERT_NEAR(new_min, -new_max, EPSILON);
+        ASSERT_GE(new_max, 0.0f);
+    }
+    return 1;
+}
+
+/* Symmetric: result covers original range */
+TEST(symmetric_covers_original_range) {
+    float new_min, new_max;
+
+    float test_mins[] = {-3.0f, 0.0f, 1.0f, -100.0f, -0.5f};
+    float test_maxs[] = {7.0f, 4.0f, 9.0f, 50.0f, 0.1f};
+
+    for (int i = 0; i < 5; i++) {
+        range_compute_symmetric(test_mins[i], test_maxs[i], &new_min, &new_max);
+        ASSERT_LE(new_min, test_mins[i]);
+        ASSERT_GE(new_max, test_maxs[i]);
+    }
+    return 1;
+}
+
+/* ========== range_parse_value tests ========== */
+
+/* Parse integer */
+TEST(parse_value_integer) {
+    float val = 0.0f;
+    ASSERT_EQ_INT(range_parse_value("42", &val), 1);
+    ASSERT_NEAR(val, 42.0f, EPSILON);
+    return 1;
+}
+
+/* Parse float */
+TEST(parse_value_float) {
+    float val = 0.0f;
+    ASSERT_EQ_INT(range_parse_value("3.14", &val), 1);
+    ASSERT_NEAR(val, 3.14f, 0.001f);
+    return 1;
+}
+
+/* Parse negative */
+TEST(parse_value_negative) {
+    float val = 0.0f;
+    ASSERT_EQ_INT(range_parse_value("-7.5", &val), 1);
+    ASSERT_NEAR(val, -7.5f, EPSILON);
+    return 1;
+}
+
+/* Parse scientific notation */
+TEST(parse_value_scientific) {
+    float val = 0.0f;
+    ASSERT_EQ_INT(range_parse_value("1.5e3", &val), 1);
+    ASSERT_NEAR(val, 1500.0f, EPSILON);
+    return 1;
+}
+
+/* Parse negative scientific notation */
+TEST(parse_value_negative_scientific) {
+    float val = 0.0f;
+    ASSERT_EQ_INT(range_parse_value("-2.5e-4", &val), 1);
+    ASSERT_NEAR(val, -2.5e-4f, 1e-8f);
+    return 1;
+}
+
+/* Parse zero */
+TEST(parse_value_zero) {
+    float val = 99.0f;
+    ASSERT_EQ_INT(range_parse_value("0", &val), 1);
+    ASSERT_NEAR(val, 0.0f, EPSILON);
+    return 1;
+}
+
+/* Parse with leading whitespace */
+TEST(parse_value_whitespace) {
+    float val = 0.0f;
+    ASSERT_EQ_INT(range_parse_value("  5.0", &val), 1);
+    ASSERT_NEAR(val, 5.0f, EPSILON);
+    return 1;
+}
+
+/* Parse empty string fails */
+TEST(parse_value_empty) {
+    float val = 99.0f;
+    ASSERT_EQ_INT(range_parse_value("", &val), 0);
+    ASSERT_NEAR(val, 99.0f, EPSILON);  /* unchanged */
+    return 1;
+}
+
+/* Parse non-numeric string fails */
+TEST(parse_value_invalid) {
+    float val = 99.0f;
+    ASSERT_EQ_INT(range_parse_value("abc", &val), 0);
+    ASSERT_NEAR(val, 99.0f, EPSILON);  /* unchanged */
+    return 1;
+}
+
+/* Parse NULL string fails */
+TEST(parse_value_null_string) {
+    float val = 99.0f;
+    ASSERT_EQ_INT(range_parse_value(NULL, &val), 0);
+    ASSERT_NEAR(val, 99.0f, EPSILON);  /* unchanged */
+    return 1;
+}
+
+/* Parse NULL value pointer fails */
+TEST(parse_value_null_value) {
+    ASSERT_EQ_INT(range_parse_value("5.0", NULL), 0);
+    return 1;
+}
+
+/* ========== Constants tests ========== */
+
+/* RANGE_POPUP_OK and RANGE_POPUP_CANCEL are distinct */
+TEST(constants_distinct) {
+    ASSERT_TRUE(RANGE_POPUP_OK != RANGE_POPUP_CANCEL);
+    ASSERT_EQ_INT(RANGE_POPUP_OK, 1);
+    ASSERT_EQ_INT(RANGE_POPUP_CANCEL, 0);
+    return 1;
+}
+
+RUN_TESTS("Range Popup")


### PR DESCRIPTION
  - src/interface/range_popup.h - Header for the range popup dialog API
  - src/interface/range_popup.c - Modal popup implementation with:
    - Editable Minimum/Maximum text fields (using Xaw asciiTextWidgetClass)
    - "Symmetric about Zero" button - sets range to [-max(|min|,|max|), max(|min|,|max|)]
    - "Reset to Global Values" button - restores the variable's full data range
    - OK / Cancel buttons
    - Modal event loop (like ncview's XtGrabExclusive approach)

  Modified files:
  - src/interface/x_interface.c - Added "Range" button in colorbar_form (same line as the colorbar, appearing to its right), initialized the popup during x_init, wired up the callback
  - src/interface/x_interface.h - Added x_set_range_button_callback() and x_range_popup_show() declarations
  - src/ushow.c - Added on_range_button() callback that opens the popup with the current variable's user_min/user_max and global_min/global_max, and updates the display on OK
  - Makefile - Added range_popup.c to USHOW_SRCS and its dependency rule

  How it works:
  1. User clicks the "Range" button (positioned after the colorbar)
  2. A modal popup appears with the current min/max values pre-filled in editable text fields
  3. User can type new values, click "Symmetric about Zero", or click "Reset to Global Values"
  4. On "OK", the variable's display range is updated and the image redraws
  5. On "Cancel", nothing changes

  Here's a summary of everything that was added:

    Tests (tests/test_range_popup.c - 24 tests):
    - 12 range_compute_symmetric tests: positive range, negative range, spanning zero, min larger abs, already symmetric, both zero, min zero, equal magnitude, small values, large values, result always symmetric, covers original range
    - 11 range_parse_value tests: integer, float, negative, scientific notation, negative scientific, zero, whitespace, empty string, invalid string, NULL string, NULL value pointer
    - 1 constants test: verifying RANGE_POPUP_OK/CANCEL values

    Architecture refactoring for testability:
    - Created src/interface/range_utils.h / range_utils.c - pure logic functions with no X11 dependency
    - range_popup.c now includes and uses range_utils.h instead of inlining the logic
    - Tests link only against range_utils.c (no X11 required)

    Documentation (README.md):
    - Added Range button, Min-/Min+/Max-/Max+ buttons to the Interface section with descriptions of the popup dialog features
    - Added test_range_popup to the test suite list