### PR TITLE
Fix building uterm with zarr (after latest grib file fix). Also exten…

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -13,8 +13,24 @@ permissions:
 
 jobs:
   test:
-    name: Run tests
+    name: Build (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            make_flags: ""
+            run_tests: "true"
+          - name: zarr-only
+            make_flags: "WITH_ZARR=1"
+            run_tests: "false"
+          - name: grib-only
+            make_flags: "WITH_GRIB=1"
+            run_tests: "false"
+          - name: zarr-and-grib
+            make_flags: "WITH_ZARR=1 WITH_GRIB=1"
+            run_tests: "false"
 
     steps:
       - name: Checkout repository
@@ -23,7 +39,24 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libnetcdf-dev pkg-config
+          sudo apt-get install -y \
+            libnetcdf-dev \
+            libblosc-dev \
+            liblz4-dev \
+            libeccodes-dev \
+            libx11-dev \
+            libxt-dev \
+            libxaw7-dev \
+            libxmu-dev \
+            libxext-dev \
+            libxpm-dev \
+            pkg-config
 
-      - name: Build and run tests
-        run: make test
+      - name: Build
+        run: |
+          make clean
+          make ${{ matrix.make_flags }} -j"$(nproc)"
+
+      - name: Run tests
+        if: matrix.run_tests == 'true'
+        run: make ${{ matrix.make_flags }} test

--- a/src/uterm.c
+++ b/src/uterm.c
@@ -836,6 +836,7 @@ static void cleanup_all(void) {
         current_dim_info = NULL;
         n_current_dims = 0;
     }
+#ifdef HAVE_GRIB
     if (fileset && fileset->files[0]->file_type == FILE_TYPE_GRIB) {
         for (int i = 0; i < n_variables; i++) {
             if (var_array && var_array[i]) {
@@ -843,6 +844,7 @@ static void cleanup_all(void) {
             }
         }
     }
+#endif
     free(var_array);
     var_array = NULL;
 


### PR DESCRIPTION
…d tests

Add missing guard
Update CI to a 4-way matrix
default
WITH_ZARR=1
WITH_GRIB=1
WITH_ZARR=1 WITH_GRIB=1
Each matrix job does a full compile smoketest build (make clean && make ...). The default matrix entry still runs the full test suite (make test), Add required Ubuntu dependencies for NetCDF, Zarr, GRIB, and X11 headers/libraries