### PR TITLE
Support FESOM2 mesh.diag.nc combined "nodes" coordinate variable

### DIFF
--- a/src/mesh.c
+++ b/src/mesh.c
@@ -167,6 +167,114 @@ static int find_coord_var(int ncid, const char **names, CoordInfo *info) {
     return -1;
 }
 
+/* FESOM2 mesh.diag.nc (and some other unstructured meshes) store the node
+ * coordinates in a single variable holding both lon and lat, e.g.
+ *   double nodes(n2, nod_n) ;   // nodes[0,:] = lon, nodes[1,:] = lat
+ * typically in RADIANS and WITHOUT a units attribute, so the name-based
+ * lon/lat search misses them entirely. This is the fallback for that layout.
+ * Returns a fully built USMesh, or NULL if no such variable is present. */
+static USMesh *mesh_create_from_combined_nodes(int ncid, const char *mesh_filename) {
+    static const char *COMBINED_NAMES[] = {
+        "nodes", "coord_nod2D", "coord_nod2d", "node_coords", NULL
+    };
+
+    int varid = -1;
+    const char *matched_name = NULL;
+    for (int i = 0; COMBINED_NAMES[i] != NULL; i++) {
+        if (nc_inq_varid(ncid, COMBINED_NAMES[i], &varid) == NC_NOERR) {
+            matched_name = COMBINED_NAMES[i];
+            break;
+        }
+        varid = -1;
+    }
+    if (varid < 0) return NULL;
+
+    int ndims = 0;
+    nc_inq_varndims(ncid, varid, &ndims);
+    if (ndims != 2) return NULL;
+
+    int dimids[2];
+    size_t d[2];
+    nc_inq_vardimid(ncid, varid, dimids);
+    nc_inq_dimlen(ncid, dimids[0], &d[0]);
+    nc_inq_dimlen(ncid, dimids[1], &d[1]);
+
+    /* One axis must be the 2-component (lon,lat) axis. */
+    size_t n_points;
+    int comp_first;                 /* 1: shape (2, n); 0: shape (n, 2) */
+    if (d[0] == 2)      { comp_first = 1; n_points = d[1]; }
+    else if (d[1] == 2) { comp_first = 0; n_points = d[0]; }
+    else return NULL;
+    if (n_points == 0) return NULL;
+
+    double *raw = malloc((size_t)2 * n_points * sizeof(double));
+    double *lon = malloc(n_points * sizeof(double));
+    double *lat = malloc(n_points * sizeof(double));
+    if (!raw || !lon || !lat) { free(raw); free(lon); free(lat); return NULL; }
+
+    if (nc_get_var_double(ncid, varid, raw) != NC_NOERR) {
+        free(raw); free(lon); free(lat);
+        return NULL;
+    }
+
+    if (comp_first) {
+        /* (2, n) C-order: first n values are lon, next n are lat */
+        for (size_t i = 0; i < n_points; i++) {
+            lon[i] = raw[i];
+            lat[i] = raw[n_points + i];
+        }
+    } else {
+        /* (n, 2) C-order: lon,lat interleaved per node */
+        for (size_t i = 0; i < n_points; i++) {
+            lon[i] = raw[2 * i];
+            lat[i] = raw[2 * i + 1];
+        }
+    }
+    free(raw);
+
+    /* Convert radians -> degrees. Honor an explicit units attribute; otherwise
+     * autodetect by range (radian lat <= ~pi/2, degree lat up to 90). */
+    char units[32];
+    read_units_attribute(ncid, varid, units, sizeof(units));
+    int radians;
+    if (is_radian_units(units)) {
+        radians = 1;
+    } else {
+        double max_abs_lon = 0.0, max_abs_lat = 0.0;
+        for (size_t i = 0; i < n_points; i++) {
+            double ao = fabs(lon[i]), al = fabs(lat[i]);
+            if (ao > max_abs_lon) max_abs_lon = ao;
+            if (al > max_abs_lat) max_abs_lat = al;
+        }
+        radians = (max_abs_lat <= M_PI / 2.0 + 1e-6) &&
+                  (max_abs_lon <= 2.0 * M_PI + 1e-6);
+    }
+    if (radians) {
+        for (size_t i = 0; i < n_points; i++) {
+            lon[i] *= RAD2DEG;
+            lat[i] *= RAD2DEG;
+        }
+    }
+
+    /* Normalize longitude to [-180, 180] */
+    for (size_t i = 0; i < n_points; i++) {
+        while (lon[i] > 180.0)  lon[i] -= 360.0;
+        while (lon[i] < -180.0) lon[i] += 360.0;
+    }
+
+    printf("Detected: combined node coordinates '%s' (%zu points, %s)\n",
+           matched_name, n_points, radians ? "radians->degrees" : "degrees");
+
+    USMesh *mesh = mesh_create(lon, lat, n_points, COORD_TYPE_1D_UNSTRUCTURED);
+    if (!mesh) { free(lon); free(lat); return NULL; }
+
+    if (mesh_filename && mesh_filename[0]) {
+        mesh->mesh_filename = strdup(mesh_filename);
+        mesh->mesh_loaded = 1;
+    }
+    return mesh;
+}
+
 USMesh *mesh_create_from_netcdf(int data_ncid, const char *mesh_filename) {
     int mesh_ncid;
     int status;
@@ -186,6 +294,14 @@ USMesh *mesh_create_from_netcdf(int data_ncid, const char *mesh_filename) {
 
     /* Find longitude variable */
     if (find_coord_var(mesh_ncid, LON_NAMES, &lon_info) != 0) {
+        /* Fallback: meshes that store lon+lat in a single combined variable
+         * (e.g. FESOM2 mesh.diag.nc "nodes"(n2, nod_n)) are not matched by the
+         * name-based search above. */
+        USMesh *combined = mesh_create_from_combined_nodes(mesh_ncid, mesh_filename);
+        if (combined) {
+            if (mesh_filename && mesh_filename[0]) nc_close(mesh_ncid);
+            return combined;
+        }
         fprintf(stderr, "Could not find longitude coordinate variable\n");
         if (mesh_filename && mesh_filename[0]) nc_close(mesh_ncid);
         return NULL;

--- a/tests/test_mesh.c
+++ b/tests/test_mesh.c
@@ -538,4 +538,44 @@ TEST(mesh_from_netcdf_ncid_not_corrupted) {
     return 1;
 }
 
+/* Test mesh_create_from_netcdf with a FESOM2-style combined nodes(n2, nod_n)
+ * coordinate variable in radians (no units attribute). Regression for the
+ * "Could not find longitude coordinate variable" failure on fesom.mesh.diag.nc. */
+TEST(mesh_from_netcdf_fesom_combined_nodes) {
+    const int N = 64;
+    const char *filename = create_test_netcdf_fesom_combined_nodes(N);
+    ASSERT_NOT_NULL(filename);
+
+    /* Loaded as a separate mesh file (data_ncid unused) */
+    USMesh *mesh = mesh_create_from_netcdf(0, filename);
+    ASSERT_NOT_NULL(mesh);
+
+    ASSERT_EQ_SIZET(mesh->n_points, (size_t)N);
+    ASSERT_EQ(mesh->coord_type, COORD_TYPE_1D_UNSTRUCTURED);
+
+    /* Node 0 was pinned to lon=pi/2, lat=pi/4 radians -> must become 90, 45 deg */
+    ASSERT_NEAR(mesh->lon[0], 90.0, EPSILON_LOOSE);
+    ASSERT_NEAR(mesh->lat[0], 45.0, EPSILON_LOOSE);
+
+    /* All coordinates must be in degree range (radians->degrees applied) */
+    for (size_t i = 0; i < mesh->n_points; i++) {
+        ASSERT_GE(mesh->lon[i], -180.0);
+        ASSERT_LE(mesh->lon[i], 180.0);
+        ASSERT_GE(mesh->lat[i], -90.5);
+        ASSERT_LE(mesh->lat[i], 90.5);
+    }
+
+    /* XYZ should be on the unit sphere */
+    for (size_t i = 0; i < mesh->n_points; i++) {
+        double x = mesh->xyz[i * 3 + 0];
+        double y = mesh->xyz[i * 3 + 1];
+        double z = mesh->xyz[i * 3 + 2];
+        ASSERT_NEAR(sqrt(x*x + y*y + z*z), 1.0, EPSILON);
+    }
+
+    mesh_free(mesh);
+    cleanup_test_file(filename);
+    return 1;
+}
+
 RUN_TESTS("Mesh")

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -665,6 +665,65 @@ static const char *create_test_netcdf_mpas_with_connectivity(
 }
 
 /*
+ * Create a test NetCDF file mimicking the classic FESOM2 fesom.mesh.diag.nc
+ * layout: node coordinates stored in a single combined variable
+ * nodes(n2, nod_n) in RADIANS with no units attribute
+ * (nodes[0,:] = lon, nodes[1,:] = lat). Node 0 is pinned to a known location
+ * (lon = pi/2, lat = pi/4) so the radians->degrees conversion can be checked
+ * deterministically; the rest are pseudo-random within the radian range.
+ */
+static const char *create_test_netcdf_fesom_combined_nodes(int n_nodes) {
+    static char filename[256];
+    snprintf(filename, sizeof(filename),
+             P_tmpdir "/test_ushow_fesom_nodes_%d_%d.nc",
+             getpid(), test_file_counter++);
+    unlink(filename);
+
+    int ncid, n2_dimid, nod_dimid, nodes_varid;
+    int dimids[2];
+    int status;
+
+    status = nc_create(filename, NC_NETCDF4, &ncid);
+    NC_CHECK(status);
+
+    status = nc_def_dim(ncid, "n2", 2, &n2_dimid);
+    NC_CHECK(status);
+    status = nc_def_dim(ncid, "nod_n", n_nodes, &nod_dimid);
+    NC_CHECK(status);
+
+    /* nodes(n2, nod_n): combined lon/lat, no units attribute (radians) */
+    dimids[0] = n2_dimid;
+    dimids[1] = nod_dimid;
+    status = nc_def_var(ncid, "nodes", NC_DOUBLE, 2, dimids, &nodes_varid);
+    NC_CHECK(status);
+    status = nc_put_att_text(ncid, nodes_varid, "long_name", 22,
+                             "nodal geo. coordinates");
+    NC_CHECK(status);
+
+    status = nc_enddef(ncid);
+    NC_CHECK(status);
+
+    /* Component-major (2, n): first n values = lon, next n = lat, in RADIANS */
+    double *raw = malloc((size_t)2 * n_nodes * sizeof(double));
+    if (!raw) { nc_close(ncid); return NULL; }
+    for (int i = 0; i < n_nodes; i++) {
+        unsigned int seed = (unsigned int)i * 1103515245U + 12345U;
+        raw[i] = -3.14159265 + 6.28318530 * (double)(seed % 10000) / 10000.0;
+        seed = seed * 1103515245U + 12345U;
+        raw[n_nodes + i] = -1.57079632 + 3.14159265 * (double)(seed % 10000) / 10000.0;
+    }
+    /* Pin node 0 to a known location so the test can check exact conversion. */
+    raw[0] = 1.57079632679;            /* lon = pi/2  -> 90 degrees */
+    raw[n_nodes + 0] = 0.78539816340;  /* lat = pi/4  -> 45 degrees */
+
+    nc_put_var_double(ncid, nodes_varid, raw);
+    free(raw);
+
+    nc_close(ncid);
+    return filename;
+}
+
+/*
  * Remove a test file.
  */
 static void cleanup_test_file(const char *filename) {


### PR DESCRIPTION
Fixes #33.

## Problem

The classic FESOM2 `fesom.mesh.diag.nc` (e.g. the CORE2 mesh) stores node lon/lat in a single combined variable `nodes(n2, nod_n)` — in **radians**, with **no `units` attribute** (`nodes[0,:]` = lon, `nodes[1,:]` = lat). The name-based coordinate search in `mesh_create_from_netcdf` only matches separate `lon`/`lat`-style variables, so loading such a mesh via `-m` aborted with:

```
Loading mesh...
Could not find longitude coordinate variable
Failed to load mesh
```

## Fix

Add a `mesh_create_from_combined_nodes` fallback in `src/mesh.c`, tried when the name-based longitude search fails. It:

- detects a combined node-coordinate variable (`nodes`, `coord_nod2D`, …);
- splits it into lon/lat, handling both `(2, n)` and `(n, 2)` layouts;
- honors an explicit `units` attribute, otherwise auto-detects radians vs degrees by value range;
- converts radians→degrees and normalizes longitude to `[-180, 180]`;
- builds the unstructured mesh.

In FESOM2 this `nodes` array holds the geographic (de-rotated) coordinates, so no grid un-rotation is needed even when the model grid itself is rotated.

## Tests

Adds the regression test `mesh_from_netcdf_fesom_combined_nodes` (`tests/test_mesh.c`), backed by a synthetic FESOM2-style `nodes(n2, nod_n)` mesh file (`tests/test_utils.h`). The full suite passes locally (`make test`).
